### PR TITLE
🐋 build(docker): remove NODE_ENV='production'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
-ENV NODE_ENV="production"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 


### PR DESCRIPTION
This PR removes NODE_ENV="production" from the Dockerfile as this blocks Vite from installing